### PR TITLE
use full header paths

### DIFF
--- a/dunepdlegacy/rce/dam/records/Data.hh
+++ b/dunepdlegacy/rce/dam/records/Data.hh
@@ -53,7 +53,7 @@
 \* ---------------------------------------------------------------------- */
 
 
-#include <dam/access/Headers.hh>
+#include <dunepdlegacy/rce/dam/access/Headers.hh>
 #include <cinttypes>
 
 

--- a/dunepdlegacy/rce/dam/records/Originator.hh
+++ b/dunepdlegacy/rce/dam/records/Originator.hh
@@ -45,7 +45,7 @@
 \* ---------------------------------------------------------------------- */
 
 
-#include <dam/access/Headers.hh>
+#include <dunepdlegacy/rce/dam/access/Headers.hh>
 #include <cinttypes>
 
 

--- a/dunepdlegacy/rce/src/CMakeLists.txt
+++ b/dunepdlegacy/rce/src/CMakeLists.txt
@@ -2,7 +2,5 @@
 
 # look for dunepdlegacy/dam
 
-###include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
-
 art_make_library( LIBRARY_NAME dunepdlegacy_rce_dataaccess )
 

--- a/dunepdlegacy/rce/src/CMakeLists.txt
+++ b/dunepdlegacy/rce/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 # look for dunepdlegacy/dam
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+###include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 art_make_library( LIBRARY_NAME dunepdlegacy_rce_dataaccess )
 

--- a/dunepdlegacy/rce/src/Headers.cc
+++ b/dunepdlegacy/rce/src/Headers.cc
@@ -46,7 +46,7 @@
 \* ---------------------------------------------------------------------- */
 
 
-#include <dam/access/Headers.hh>
+#include <dunepdlegacy/rce/dam/access/Headers.hh>
 #include <cinttypes>
 #include <cstdio>
 

--- a/dunepdlegacy/rce/src/TpcCompressed-Impl.hh
+++ b/dunepdlegacy/rce/src/TpcCompressed-Impl.hh
@@ -51,7 +51,7 @@
 \* ---------------------------------------------------------------------- */
 
 
-#include  "dam/access/TpcCompressed.hh"
+#include  "dunepdlegacy/rce/dam/access/TpcCompressed.hh"
 #include "dunepdlegacy/rce/dam/records/TpcCompressed.hh"
 
 

--- a/dunepdlegacy/rce/src/TpcStreamAssessor.cc
+++ b/dunepdlegacy/rce/src/TpcStreamAssessor.cc
@@ -53,7 +53,7 @@
 #include "TpcToc-Impl.hh"
 #include "TpcPacket-Impl.hh"
 
-#include <dam/access/WibFrame.hh>
+#include <dunepdlegacy/rce/dam/access/WibFrame.hh>
 
 #include <cstdint>
 #include <stdio.h>


### PR DESCRIPTION
Remove `include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)` and use full header paths. 